### PR TITLE
Add proper "unsafe" to SharedMemoryObject::{get,get_mut} functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,22 @@ let pid = unsafe { fork() };
 assert!(pid >= 0);
 
 if pid == 0 {
-    assert_eq!(*shared.get(), 123);
-    *shared.get_mut() = 456;
-    sleep(Duration::from_millis(40));
-    assert_eq!(*shared.get(), 789);
+    // SAFETY: Relying on timings, real program should 
+    // use proper synchronization primitives
+    unsafe {
+        assert_eq!(*shared.get(), 123);
+        *shared.get_mut() = 456;
+        sleep(Duration::from_millis(40));
+        assert_eq!(*shared.get(), 789);
+    }
 } else {
-    sleep(Duration::from_millis(20));
-    assert_eq!(*shared.get(), 456);
-    *shared.get_mut() = 789;
+    // SAFETY: Relying on timings, real program should 
+    // use proper synchronization primitives
+    unsafe {
+        sleep(Duration::from_millis(20));
+        assert_eq!(*shared.get(), 456);
+        *shared.get_mut() = 789;
+    }
 }
 ```
 

--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -78,7 +78,9 @@ impl SharedCondvar {
     /// [`last_os_error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html#method.last_os_error
     pub fn new() -> std::io::Result<Self> {
         let mut condvar = SharedMemoryObject::new(PTHREAD_COND_INITIALIZER)?;
-        initialize_condvar(condvar.get_mut())?;
+        // SAFETY: The condvar is exclusively owned by current thread
+        // due its not shared because under construction
+        unsafe { initialize_condvar(condvar.get_mut())? };
 
         let owner_pid = getpid();
         Ok(Self { condvar, owner_pid })

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -81,7 +81,9 @@ impl SharedMutex {
     /// [`last_os_error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html#method.last_os_error.
     pub fn new() -> std::io::Result<Self> {
         let mut mutex = SharedMemoryObject::new(PTHREAD_MUTEX_INITIALIZER)?;
-        initialize_mutex(mutex.get_mut())?;
+        // SAFETY: The mutex is exclusively owned by current thread
+        // due its not shared because under construction
+        unsafe { initialize_mutex(mutex.get_mut())? };
 
         let owner_pid = getpid();
         Ok(Self { mutex, owner_pid })
@@ -114,7 +116,7 @@ impl SharedMutex {
     }
 
     pub(crate) fn get_mut(&mut self) -> *mut pthread_mutex_t {
-        self.mutex.get_mut()
+        self.mutex.get_ptr()
     }
 }
 

--- a/tests/shared_memory.rs
+++ b/tests/shared_memory.rs
@@ -6,7 +6,9 @@ pub use process_sync::private::SharedMemoryObject;
 
 use common::{sleep, TestOutput};
 
-fn main() {
+// SAFETY: Currently relying on sleeping to luckily avoid
+// data races for tests
+unsafe fn main_test() {
     let mut test_output = TestOutput::new(&["123", "123", "456", "789"]);
 
     let mut value = SharedMemoryObject::new(123).expect("cannot create SharedMemoryObject");
@@ -28,4 +30,8 @@ fn main() {
     test_output.write_line(&format!("{}", value.get()));
     *value.get_mut() = 789;
     sleep(40);
+}
+
+fn main() {
+    unsafe { main_test(); }
 }


### PR DESCRIPTION
# Background

Currently the `get` and `get_mut` is safe when it should be unsafe.

# Why?

The shared memory is shared between process therefore programmer/caller must asserts that the piece of shared memory is safe to access by some way such as but not limited to the fact that the shared memory object is exclusively owned (e.g. before fork or after child exits) or adequately protected by synchronization primitive such as mutex.

# Why? (Longer more explained version)

If there no unsafe, safe code can trigger data race and UB. Let's see the following code which can trigger those in safe code which should not happen in safe Rust (as those are the very thing safe Rust trying to prevent).

```rust
struct Data {
    fieldA: u32
}

impl Data {
    pub fn do_something(&mut self) {
         // <- (Point A)
         self.fieldA += 1;
         // <- (Point B)
         self.fieldA -= 1;
         // <- (Point C)
    }
  
    pub fn check(&self) {
        assert_eq!(self.fieldA, 0);
    }
}

let mut shared = SharedMemoryObject::new(Data { fieldA: 0 })?;

let pid = unsafe { fork() };
assert!(pid >= 0);

if pid == 0 {
    shared.get_mut().do_something();
} else {
    shared.get().check();
}
```

Two possible thing can occur (do note that its occuring in safe code where Rust trust you that mutable reference is exclusive!)
1. Never panic, if Rust decided to optimize `do_something` into no-op because it assumes that nothing can read it (which is obviously not always true) and increment followed by decrement does nothing and nobody ever see mid result which is obviously not always true too.
2. Either undetermisticly panic/not panic, depends on when `fieldA` is loaded (whether its on Point A, Point B or Point C) and if Rust decided to not optimize `do_something`

There is potential UB with safe code. (ignores the unsafe `fork()` in the meanwhile) The `Data::do_something` expect mutable reference to itself and a fork of process also can potentially create an immutable reference to the same underlying shared memory while mutable one still exist which is forbidden in Rust because the memory is shared and supposedly exclusive reference modifies it while forked version also potentially read it with immutable reference which is exactly what borrow checker tries to prevent but there no such luxury here due borrow checker can't comprehend fork-ing.

# Conclusion

Safe Rust code must never trigger UB[1] but the current version of `get` and `get_mut` can trigger UB in safe Rust also shared memory imply its shared anyway so the `get` and `get_mut` be modified to be unsafe to let programmer know to be careful.

# Footnotes

[1] Source: https://doc.rust-lang.org/nomicon/meet-safe-and-unsafe.html

pssttt, forking is just a glorified way to create new thread with everything duplicated (except resources specifically marked as shared) so usual concurreny problems on shared memory should be handled as such.